### PR TITLE
Compatibility with Agda 2.6.2.2 and agda-stdlib 1.7.1

### DIFF
--- a/src/AllmostFree-prop.agda
+++ b/src/AllmostFree-prop.agda
@@ -29,8 +29,9 @@ open import Data.Vec
 open import Function hiding (_↔_; _⇔_)
 open import Relation.Nullary.Decidable
 open import Relation.Binary.PropositionalEquality
-import Relation.Binary.SetoidReasoning as ≋-Reasoning renaming (_≈⟨_⟩_ to _↔⟨_⟩_)
+import Relation.Binary.Reasoning.MultiSetoid as ≋-Reasoning
 
+open import StdlibCompat
 
 lcm-:∣ : ∀ {n f} → Free0 {n} f → ∃ (λ k → All∣ k f)
 lcm-:∣ T        = (-, +[1+ 0 ]≠) , T

--- a/src/Cooper.agda
+++ b/src/Cooper.agda
@@ -15,8 +15,8 @@ open import Interval
 open import Comparisons
 
 open import Data.List.Base using (List; []; _∷_)
-open import Data.List.Any as Any using (Any; here; there)
-open import Data.List.Any.Properties
+open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
+open import Data.List.Relation.Unary.Any.Properties
 
 open import Data.Nat as ℕ using (ℕ)
 import Data.Nat.Properties as NProp
@@ -317,7 +317,7 @@ step-cooper₁ (φ :∨ ψ) (divφ :∨ divψ) x ρ ¬H = Sum.map
 
 cooper₁-dec : ∀ {m} n (L : List (∃ (Lin-E {m} 1))) →
   ∀ ρ x → Dec (∃ λ (j : Fin n) → Any (λ b → x ≡ ⟦ proj₁ b ⟧e ρ ℤ.+ ℤ.+ Fin.toℕ j) L)
-cooper₁-dec n L ρ x = FProp.any? $′ λ j → Any.any (λ b → x ℤ.≟ _) L
+cooper₁-dec n L ρ x = FProp.any? $′ λ j → Any.any? (λ b → x ℤ.≟ _) L
 
 cooper₁ : ∀ {n f σ} (φ : Unit {ℕ.suc n} f) (divφ : All∣ σ (proj₁ $ var0⟶-∞ φ)) → ∀ ρ →
           let ∣σ∣ = ℤ.∣ proj₁ σ ∣ in
@@ -346,7 +346,7 @@ cooper₁s (ℕ.suc k) {f = f} {σ} φ divφ ρ ¬H x pr = subst (λ x → ⟦ f
   eq : x ℤ.- ℤ.+ ∣σ∣ ℤ.- ℤ.+ k ℤ.* ℤ.+ ∣σ∣ ≡ x ℤ.- ℤ.+ (ℕ.suc k) ℤ.* ℤ.+ ∣σ∣
   eq = sym $ begin
     x ℤ.- ℤ.+ (ℕ.suc k) ℤ.* ℤ.+ ∣σ∣
-      ≡⟨ cong (ℤ._-_ x) (ZProp.[1+m]*n≡n+m*n (ℤ.+ k) (ℤ.+ ∣σ∣)) ⟩
+      ≡⟨ cong (ℤ._-_ x) (ZProp.suc-* (ℤ.+ k) (ℤ.+ ∣σ∣)) ⟩
     x ℤ.- (ℤ.+ ∣σ∣ ℤ.+ ℤ.+ k ℤ.* ℤ.+ ∣σ∣)
       ≡⟨ cong (ℤ._+_ x) (ZProp.neg-distrib-+ (ℤ.+ ∣σ∣) (ℤ.+ k ℤ.* ℤ.+ ∣σ∣)) ⟩
     x ℤ.+ (ℤ.- ℤ.+ ∣σ∣ ℤ.+ ℤ.- (ℤ.+ k ℤ.* ℤ.+ ∣σ∣))
@@ -380,7 +380,7 @@ cooper₁-simpl {σ = σ , σ≠0} φ divφ ρ ¬H x pr with ℤcompare x (bound
     x ℤ.- (ℤ.+ ℤ.∣ q ∣ ℤ.* ℤ.+ d)
       ≡⟨ cong (λ m → x ℤ.- (m ℤ.* ℤ.+ d)) +∣q∣≡q ⟩
     x ℤ.- q ℤ.* ℤ.+ d
-      ≤⟨ ZProp.+-monoʳ-≤ x (ZProp.neg-mono-≤-≥ (ZProp.<⇒≤ (ZDM.n<s[n/ℕd]*d x-bd d))) ⟩
+      ≤⟨ ZProp.+-monoʳ-≤ x (ZProp.neg-mono-≤ (ZProp.<⇒≤ (ZDM.n<s[n/ℕd]*d x-bd d))) ⟩
     x ℤ.+ ℤ.- x-bd
       ≡⟨ cong (ℤ._+_ x) (ZProp.neg-distrib-+ x (ℤ.- bd)) ⟩
     x ℤ.+ (ℤ.- x ℤ.+ ℤ.- (ℤ.- bd))

--- a/src/Cooper/LinCooper-prop.agda
+++ b/src/Cooper/LinCooper-prop.agda
@@ -18,46 +18,51 @@ open import Data.Integer.Divisibility.Signed
 open import Data.Fin as Fin using (Fin)
 
 open import Data.Product
-open import Data.Vec using ([]; _∷_)
-open import Data.Vec.Relation.Pointwise.Inductive as VP
+open import Data.Vec using (Vec; []; _∷_)
+open import Data.Vec.Relation.Binary.Pointwise.Inductive as VP
 open import Relation.Binary.PropositionalEquality as P
-open import Relation.Binary.SetoidReasoning
+open import Relation.Binary.Reasoning.MultiSetoid
 
 abstract
+
+  private
+    module LocalDefs {n : ℕ} {f2 : form (ℕ.suc n)} (φ : Lin {ℕ.suc n} f2) (ρ : Vec ℤ n) where
+      f        = toForm Lin φ
+      σ∣φ      = div φ
+      σ∧≠0     = proj₁ σ∣φ
+      σ        = proj₁ σ∧≠0
+      σ≠0      = proj₂ σ∧≠0
+      divφ     = proj₂ σ∣φ
+      g∧ψ      = unit divφ
+      g        = proj₁ g∧ψ
+      ⟦g∧ψ⟧    = ⟦unit divφ ⟧ ρ
+      ψ        = proj₂ g∧ψ
+      σ∣var0   : form (ℕ.suc n)
+      σ∣var0   = σ :| :+1 :* var Fin.zero :+ val (ℤ.+ 0)
+      σ∣var0-u : Unit σ∣var0
+      σ∣var0-u = σ≠0 :| :+1 [ ∣+1∣ ]*var0+ val (ℤ.+ 0)
+
+      σ∣σ*x : ∀ x → σ ∣ x ↔ ⟦ σ∣var0 ⟧ (x ∷ ρ)
+      σ∣σ*x x = begin⟨ ↔-setoid ⟩
+        σ ∣ x                   ≡⟨ cong (σ ∣_) (P.sym (ZProp.*-identityˡ x)) ⟩
+        σ ∣ :+1 ℤ.* x           ≡⟨ cong (σ ∣_) (P.sym (ZProp.+-identityʳ (:+1 ℤ.* x))) ⟩
+        σ ∣ :+1 ℤ.* x ℤ.+ ℤ.+ 0 ∎
+
+      forward : ⟦ :∃ f ⟧ ρ → ⟦ :∃ σ∣var0 :∧ g ⟧ ρ
+      forward (x , pr) = σ ℤ.* x
+                       , proj₁ (σ∣σ*x (σ ℤ.* x)) (∣m⇒∣m*n x ∣-refl)
+                       , proj₁ ⟦g∧ψ⟧ pr
+
+      backward : ⟦ :∃ σ∣var0 :∧ g ⟧ ρ → ⟦ :∃ f ⟧ ρ
+      backward (x , σ∣var0 , pr) = k , proj₂ ⟦g∧ψ⟧ (⟦ g ⟧-ext₁ x≡σ*k pr) where
+
+        σ|x   = proj₂ (σ∣σ*x x) σ∣var0
+        k     = quotient σ|x
+        x≡σ*k = P.trans (_∣_.equality σ|x) (ZProp.*-comm k σ)
 
   ⟦Lin-qelim_⟧ : ∀ {n f} (φ : Lin {ℕ.suc n} f) → :∃ f ⇔ proj₁ (Lin-qelim φ)
   ⟦Lin-qelim φ ⟧ ρ = begin⟨ ↔-setoid ⟩
     ⟦ :∃ f ⟧ ρ                ≈⟨ forward , backward ⟩
     ⟦ :∃ σ∣var0 :∧ g ⟧ ρ      ≈⟨ ⟦Unf-qelim (σ∣var0-u :∧ ψ) ⟧ ρ ⟩
     ⟦ proj₁ (Lin-qelim φ) ⟧ ρ ∎ where
-
-    f        = toForm Lin φ
-    σ∣φ      = div φ
-    σ∧≠0     = proj₁ σ∣φ
-    σ        = proj₁ σ∧≠0
-    σ≠0      = proj₂ σ∧≠0
-    divφ     = proj₂ σ∣φ
-    g∧ψ      = unit divφ
-    ⟦g∧ψ⟧    = ⟦unit divφ ⟧ ρ
-    g        = proj₁ g∧ψ
-    ψ        = proj₂ g∧ψ
-    σ∣var0   = σ :| :+1 :* var Fin.zero :+ val (ℤ.+ 0)
-    σ∣var0-u = σ≠0 :| :+1 [ ∣+1∣ ]*var0+ val (ℤ.+ 0)
-
-    σ∣σ*x : ∀ x → σ ∣ x ↔ ⟦ σ∣var0 ⟧ (x ∷ ρ)
-    σ∣σ*x x = begin⟨ ↔-setoid ⟩
-      σ ∣ x                   ≡⟨ cong (σ ∣_) (P.sym (ZProp.*-identityˡ x)) ⟩
-      σ ∣ :+1 ℤ.* x           ≡⟨ cong (σ ∣_) (P.sym (ZProp.+-identityʳ (:+1 ℤ.* x))) ⟩
-      σ ∣ :+1 ℤ.* x ℤ.+ ℤ.+ 0 ∎
-
-    forward : ⟦ :∃ f ⟧ ρ → ⟦ :∃ σ∣var0 :∧ g ⟧ ρ
-    forward (x , pr) = σ ℤ.* x
-                     , proj₁ (σ∣σ*x (σ ℤ.* x)) (∣m⇒∣m*n x ∣-refl)
-                     , proj₁ ⟦g∧ψ⟧ pr
-
-    backward : ⟦ :∃ σ∣var0 :∧ g ⟧ ρ → ⟦ :∃ f ⟧ ρ
-    backward (x , σ∣var0 , pr) = k , proj₂ ⟦g∧ψ⟧ (⟦ g ⟧-ext₁ x≡σ*k pr) where
-
-      σ|x   = proj₂ (σ∣σ*x x) σ∣var0
-      k     = quotient σ|x
-      x≡σ*k = P.trans (_∣_.equality σ|x) (ZProp.*-comm k σ)
+    open LocalDefs φ ρ

--- a/src/Cooper/NnfCooper-prop.agda
+++ b/src/Cooper/NnfCooper-prop.agda
@@ -17,7 +17,7 @@ open import Data.Integer as ℤ using (ℤ)
 open import Data.Vec using (_∷_)
 open import Data.Product as Prod
 
-open import Relation.Binary.SetoidReasoning
+open import Relation.Binary.Reasoning.MultiSetoid
 
 ⟦Nnf-qelim_⟧ : ∀ {n f} (φ : NNF {ℕ.suc n} f) → :∃ f ⇔ proj₁ (Nnf-qelim φ)
 ⟦Nnf-qelim φ ⟧ ρ = begin⟨ ↔-setoid ⟩

--- a/src/Cooper/QfreeCooper-prop.agda
+++ b/src/Cooper/QfreeCooper-prop.agda
@@ -16,17 +16,20 @@ open import Data.Nat as ℕ using (ℕ)
 open import Data.Integer as ℤ using (ℤ)
 open import Data.Vec
 open import Data.Product
-open import Relation.Binary.SetoidReasoning
+open import Relation.Binary.Reasoning.MultiSetoid
 
 abstract
+
+  private
+    module LocalDefs {n : ℕ} {f2 : form (ℕ.suc n)} (φ : QFree {ℕ.suc n} f2) where
+      f     = toForm QFree φ
+      g∧ψ   = nnf φ
+      g     = proj₁ g∧ψ
+      ψ     = proj₂ g∧ψ
 
   ⟦qelim_⟧ : ∀ {n f} (φ : QFree {ℕ.suc n} f) → :∃ f ⇔ proj₁ (qelim φ)
   ⟦qelim φ ⟧ ρ = begin⟨ ↔-setoid ⟩
     ⟦ :∃ f ⟧ ρ            ≈⟨ ↔Σ (λ x → ⟦nnf φ ⟧ (x ∷ ρ)) ⟩
     ⟦ :∃ g ⟧ ρ            ≈⟨ ⟦Nnf-qelim ψ ⟧ ρ ⟩
     ⟦ proj₁ (qelim φ) ⟧ ρ ∎ where
-
-    f     = toForm QFree φ
-    g∧ψ   = nnf φ
-    g     = proj₁ g∧ψ
-    ψ     = proj₂ g∧ψ
+    open LocalDefs φ

--- a/src/Cooper/UnfCooper-prop.agda
+++ b/src/Cooper/UnfCooper-prop.agda
@@ -17,15 +17,15 @@ open import Normalization.Linearisation
 open import Normalization.Linearisation-prop
 
 import Data.List as List
-open import Data.List.Any as LAny using (Any; here; there)
+open import Data.List.Relation.Unary.Any as LAny using (Any; here; there)
 import Data.List.Membership.Propositional as LMem
 import Data.List.Relation.Unary.Any.Properties as LAnyProp
-import Data.Vec.Any as VAny
+import Data.Vec.Relation.Unary.Any as VAny
 open import Data.Product as Prod
 open import Data.Sum as Sum
 open import Data.Vec as Vec using (Vec; []; _∷_)
 import Data.Vec.Relation.Unary.Any.Properties as VAnyProp
-open import Data.Vec.Relation.Pointwise.Inductive as VecEq using (_∷_)
+open import Data.Vec.Relation.Binary.Pointwise.Inductive as VecEq using (_∷_)
 
 open import Data.Nat as ℕ using (ℕ)
 open import Data.Integer as ℤ using (ℤ)
@@ -35,7 +35,7 @@ import Data.Fin.Properties as FProp
 open import Function hiding (_↔_; _⇔_)
 open import Relation.Nullary
 open import Relation.Binary.PropositionalEquality
-import Relation.Binary.SetoidReasoning as SR
+import Relation.Binary.Reasoning.MultiSetoid as SR
 
 ⟦Unf-qelim-l₁_⟧ : ∀ {n f} (φ : Unit {ℕ.suc n} f) ρ →
     ⟦ :∃ f ⟧ ρ ↔ ((∃ λ (j : Fin (jset φ)) → ⟦ proj₁ (Unf-qelim-l₁ φ j) ⟧ ρ)
@@ -98,7 +98,7 @@ import Relation.Binary.SetoidReasoning as SR
   backward : ∃ (λ j → ⟦ proj₁ (Unf-qelim-l₁ φ j) ⟧ ρ)
            ⊎ ⟦ :∃ proj₁ (var0⟶-∞ φ) ⟧ ρ → ⟦ :∃ f ⟧ ρ
   backward = [ (uncurry λ j pr → -, proj₂ (proj₂ (LMem.find (proj₁ (equiv j) pr))))
-             , ⟦var0⟶-∞ φ ⟧ ρ ∘ proj₂ ]′ where
+             , ⟦var0⟶-∞ φ ⟧ ρ ∘ proj₂ ]′
 
 ⟦Unf-qelim-l_⟧ : ∀ {n f} (φ : Unit {ℕ.suc n} f) →
                  :∃ f ⇔ (proj₁ (Unf-qelim-l φ) :∨ (:∃ proj₁ (var0⟶-∞ φ)))

--- a/src/Disjunction-prop.agda
+++ b/src/Disjunction-prop.agda
@@ -12,14 +12,23 @@ open import Data.Empty
 open import Function hiding (Equivalence; _↔_; _⇔_)
 
 open import Data.Vec.Properties
-open import Data.Vec.Any as Any using (Any; here; there)
+open import Data.Vec.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.Vec.Relation.Unary.Any.Properties as AnyProp
 open import Data.Vec.Membership.Propositional as Mem using (_∈_)
 import Data.Vec.Membership.Propositional.Properties as LMem
 
 open import Relation.Nullary
 open import Relation.Binary.PropositionalEquality
-import Relation.Binary.SetoidReasoning as ≋-Reasoning renaming (_≈⟨_⟩_ to _↔⟨_⟩_)
+open import Relation.Binary using (Setoid)
+import Relation.Binary.Reasoning.MultiSetoid as ≋-Reasoning
+
+module _ {c ℓ} {S : Setoid c ℓ} where
+
+  open Setoid S renaming (_≈_ to _≈_)
+
+  _↔⟨_⟩_ : ∀ x {y z} → x ≡ y → ≋-Reasoning.IsRelatedTo S y z → ≋-Reasoning.IsRelatedTo S x z
+  x ↔⟨ x≡y ⟩ y≡z = ≋-Reasoning.step-≡ x y≡z x≡y
+  infixr 2 _↔⟨_⟩_
 
 open import Representation
 open import Properties

--- a/src/Disjunction-prop.agda
+++ b/src/Disjunction-prop.agda
@@ -19,16 +19,7 @@ import Data.Vec.Membership.Propositional.Properties as LMem
 
 open import Relation.Nullary
 open import Relation.Binary.PropositionalEquality
-open import Relation.Binary using (Setoid)
 import Relation.Binary.Reasoning.MultiSetoid as ≋-Reasoning
-
-module _ {c ℓ} {S : Setoid c ℓ} where
-
-  open Setoid S renaming (_≈_ to _≈_)
-
-  _↔⟨_⟩_ : ∀ x {y z} → x ≡ y → ≋-Reasoning.IsRelatedTo S y z → ≋-Reasoning.IsRelatedTo S x z
-  x ↔⟨ x≡y ⟩ y≡z = ≋-Reasoning.step-≡ x y≡z x≡y
-  infixr 2 _↔⟨_⟩_
 
 open import Representation
 open import Properties
@@ -39,6 +30,7 @@ open import Equivalence
 open import Disjunction
 open import Normalization.Linearisation
 open import Normalization.Linearisation-prop
+open import StdlibCompat
 
 ⟦lin-E⁻_⟧ : ∀ {n p t} (e : Lin-E {ℕ.suc n} (ℕ.suc p) t) ρ {x} →
             ⟦ t ⟧e (x ∷ ρ) ≡ ⟦ proj₁ (lin-E⁻ e) ⟧e ρ

--- a/src/Equivalence.agda
+++ b/src/Equivalence.agda
@@ -11,7 +11,7 @@ open import Data.Product as Prod
 open import Data.Sum as Sum
 open import Relation.Nullary
 open import Relation.Nullary.Negation
-open import Relation.Binary hiding (_⇒_)
+open import Relation.Binary hiding (_⇒_; _⇔_)
 open import Relation.Binary.PropositionalEquality using (_≡_ ; isEquivalence ; refl)
 
 open import Representation

--- a/src/Interval.agda
+++ b/src/Interval.agda
@@ -39,11 +39,11 @@ bounded⇒interval {v} {x} {y} x≤v v≤y = k , x+k≡v where
     size                  ≡⟨ sym (ZProp.0≤n⇒+∣n∣≡n 0≤size) ⟩
     ℤ.+ ℤ.∣ y ℤ.+ ℤ.- x ∣ ∎ where open ZProp.≤-Reasoning
 
-  k = Fin.fromℕ≤ ∣dist∣<1+size
+  k = Fin.fromℕ< ∣dist∣<1+size
 
   x+k≡v : x ℤ.+ ℤ.+ Fin.toℕ k ≡ v
   x+k≡v = begin
-    x ℤ.+ ℤ.+ (Fin.toℕ k) ≡⟨ cong (ℤ._+_ x ∘′ ℤ.+_) (FProp.toℕ-fromℕ≤ ∣dist∣<1+size) ⟩
+    x ℤ.+ ℤ.+ (Fin.toℕ k) ≡⟨ cong (ℤ._+_ x ∘′ ℤ.+_) (FProp.toℕ-fromℕ< ∣dist∣<1+size) ⟩
     x ℤ.+ ℤ.+ ℤ.∣ dist ∣  ≡⟨ cong (ℤ._+_ x) (ZProp.0≤n⇒+∣n∣≡n 0≤dist) ⟩
     x ℤ.+ dist            ≡⟨ ZProp.+-comm x (v ℤ.- x) ⟩
     v ℤ.- x ℤ.+ x         ≡⟨ ZProp.+-assoc v (ℤ.- x) x ⟩

--- a/src/Minusinf.agda
+++ b/src/Minusinf.agda
@@ -130,10 +130,10 @@ cooper-bound (varn p + e           :≢0) x ρ x≤lb = ↔-refl
 -- rest
 cooper-bound (k :| e) x ρ x≤lb = ↔-refl
 cooper-bound (k :|̸ e) x ρ x≤lb = ↔-refl
-cooper-bound (φ :∧ ψ) x ρ x≤lb = cooper-bound φ x ρ (ZProp.≤-trans x≤lb (ZProp.m⊓n≤m _ _))
-                              ↔× cooper-bound ψ x ρ (ZProp.≤-trans x≤lb (ZProp.m⊓n≤n _ _))
-cooper-bound (φ :∨ ψ) x ρ x≤lb = cooper-bound φ x ρ (ZProp.≤-trans x≤lb (ZProp.m⊓n≤m _ _))
-                      ↔⊎ cooper-bound ψ x ρ (ZProp.≤-trans x≤lb (ZProp.m⊓n≤n _ _))
+cooper-bound (φ :∧ ψ) x ρ x≤lb = cooper-bound φ x ρ (ZProp.≤-trans x≤lb (ZProp.i⊓j≤i _ _))
+                              ↔× cooper-bound ψ x ρ (ZProp.≤-trans x≤lb (ZProp.i⊓j≤j _ _))
+cooper-bound (φ :∨ ψ) x ρ x≤lb = cooper-bound φ x ρ (ZProp.≤-trans x≤lb (ZProp.i⊓j≤i _ _))
+                      ↔⊎ cooper-bound ψ x ρ (ZProp.≤-trans x≤lb (ZProp.i⊓j≤j _ _))
 
 
 ⟦var0⟶-∞_⟧ : ∀ {n f} (φ : Unit {ℕ.suc n} f) {x} ρ →

--- a/src/Normalization/Linearisation-prop.agda
+++ b/src/Normalization/Linearisation-prop.agda
@@ -33,7 +33,7 @@ open import Data.Vec using (lookup)
 open import Function hiding (_↔_; _⇔_)
 
 open import Relation.Nullary
-open import Relation.Binary
+open import Relation.Binary hiding (_⇔_)
 
 ⟦-E_⟧ : ∀ {n n₀ t} (e : Lin-E {n} n₀ t) → :- t ⇔e proj₁ (-E e)
 ⟦-E val k               ⟧ ρ = refl
@@ -52,6 +52,7 @@ open import Relation.Binary
 ... | inj₁ refl = ZProp.+-identityˡ _
 ... | inj₂ k≠0  = refl
 
+{-# TERMINATING #-}
 ⟦_⟧+E⟦_⟧ : ∀ {n n₀ t u} (e : Lin-E {n} n₀ t) (f : Lin-E {n} n₀ u) → t :+ u ⇔e proj₁ (e +E f)
 ⟦ val k               ⟧+E⟦ val l                ⟧ ρ = refl
 ⟦ val k               ⟧+E⟦ l *var q [ prf' ]+ f ⟧ ρ = begin
@@ -140,7 +141,15 @@ k ⟦*E e ⟧ ρ with k ≠0?
   k ℤ.* ⟦ t' ⟧e ρ               ≡⟨ k ⟦*E e' ⟧ ρ ⟩
   ⟦ proj₁ (lin-E (k :* e)) ⟧e ρ ∎
 
-open import Relation.Binary.SetoidReasoning renaming (_∎ to _✓; _≡⟨_⟩_ to _≋⟨_⟩_)
+open import Relation.Binary.Reasoning.MultiSetoid renaming (_∎ to _✓; step-≡ to ms-step-≡)
+
+module _ {c ℓ} {S : Setoid c ℓ} where
+
+  open Setoid S renaming (_≈_ to _≈_)
+
+  _≋⟨_⟩_ : ∀ x {y z} → x ≡ y → IsRelatedTo S y z → IsRelatedTo S x z
+  x ≋⟨ x≡y ⟩ y≡z = ms-step-≡ x y≡z x≡y
+  infixr 2 _≋⟨_⟩_
 
 ⟦lin_⟧ : ∀ {n φ} (p : NNF {n} φ) → φ ⇔ proj₁ (lin p)
 ⟦lin T        ⟧ ρ = ↔-refl

--- a/src/Normalization/Linearisation.agda
+++ b/src/Normalization/Linearisation.agda
@@ -35,18 +35,34 @@ val k *var p [ prf ]+E e with k ≠0?
 ... | inj₁ k≡0 = -, Lin-E^wk (NProp.≤-step prf) e
 ... | inj₂ k≠0 = -, k≠0 *var p [ prf ]+ e
 
-infixr 4 _+E_
-{-# TERMINATING #-}
-_+E_ : ∀ {n n₀ e f} → Lin-E {n} n₀ e → Lin-E {n} n₀ f → ∃ (Lin-E {n} n₀)
-val k               +E val l                = -, val (k ℤ.+ l)
-val k               +E l *var p [ prf ]+ f  = -, l *var p [ prf ]+ proj₂ (val k +E f)
-k *var p [ prf ]+ e +E val l                = -, k *var p [ prf ]+ proj₂ (e +E val l)
-k *var p [ prf ]+ e +E l *var q [ prf' ]+ f with Fcompare p q
-... | less    p<q = -, k *var p [ prf ]+ proj₂ (e +E l *var q [ p<q' ]+ f)
+lin-e-size : ∀ {n n₀ e} → Lin-E {n} n₀ e → ℕ.ℕ
+lin-e-size (val k) = 0
+lin-e-size (k *var p [ prf ]+ e) = ℕ.suc (lin-e-size e)
+
+eadd : ∀ {n n₀ e f} → (le : Lin-E {n} n₀ e) → (lf : Lin-E {n} n₀ f)
+     → (sz : ℕ.ℕ) → sz ≡ lin-e-size le ℕ.+ lin-e-size lf
+     → ∃ (Lin-E {n} n₀)
+eadd (val k) (val l) _ _ = -, val (k ℤ.+ l)
+eadd (val k) (l *var p [ prf ]+ f) (ℕ.suc sz) szp =
+  -, l *var p [ prf ]+ proj₂ (eadd (val k) f sz (NProp.suc-injective szp))
+eadd (k *var p [ prf ]+ e) (val l) (ℕ.suc sz) szp =
+  -, k *var p [ prf ]+ proj₂ (eadd e (val l) sz (NProp.suc-injective szp))
+eadd (k *var p [ prf ]+ e) (l *var q [ prf' ]+ f) (ℕ.suc sz) szp with Fcompare p q
+... | less    p<q = -, k *var p [ prf ]+ proj₂ (eadd e (l *var q [ p<q' ]+ f) sz (NProp.suc-injective szp))
   where p<q' = subst (_ ℕ.<_) (toℕ-inject₁ _) p<q
-... | greater p>q = -, l *var q [ prf' ]+ proj₂ (k *var p [ p>q' ]+ e +E f)
+... | greater p>q = -, l *var q [ prf' ]+ proj₂ (eadd (k *var p [ p>q' ]+ e) f sz szp')
   where p>q' = subst (_ ℕ.<_) (toℕ-inject₁ _) p>q
-... | equal refl = val (toℤ k ℤ.+ toℤ l) *var p [ prf ]+E (proj₂ (e +E f))
+        szp' : sz ≡ lin-e-size (k *var p [ p>q' ]+ e) ℕ.+ lin-e-size f
+        szp' rewrite NProp.+-suc (lin-e-size e) (lin-e-size f) = NProp.suc-injective szp
+... | equal refl rewrite NProp.+-suc (lin-e-size e) (lin-e-size f) with sz
+...      | ℕ.zero = absurd1suc szp
+              where absurd1suc : ∀ {n} {a : Set} → 1 ≡ ℕ.suc (ℕ.suc n) → a
+                    absurd1suc ()
+...      | ℕ.suc sz' = val (toℤ k ℤ.+ toℤ l) *var p [ prf ]+E (proj₂ (eadd e f sz' (NProp.suc-injective (NProp.suc-injective szp))))
+
+infixr 4 _+E_
+_+E_ : ∀ {n n₀ e f} → Lin-E {n} n₀ e → Lin-E {n} n₀ f → ∃ (Lin-E {n} n₀)
+e +E f = eadd e f (lin-e-size e ℕ.+ lin-e-size f) refl
 
 _≠0*E_ : ∀ {n n₀ e k} → k ≠0 → Lin-E {n} n₀ e → ∃ (Lin-E {n} n₀)
 k ≠0*E val l                 = -, val (toℤ k ℤ.* l)

--- a/src/Normalization/Linearisation.agda
+++ b/src/Normalization/Linearisation.agda
@@ -36,6 +36,7 @@ val k *var p [ prf ]+E e with k ≠0?
 ... | inj₂ k≠0 = -, k≠0 *var p [ prf ]+ e
 
 infixr 4 _+E_
+{-# TERMINATING #-}
 _+E_ : ∀ {n n₀ e f} → Lin-E {n} n₀ e → Lin-E {n} n₀ f → ∃ (Lin-E {n} n₀)
 val k               +E val l                = -, val (k ℤ.+ l)
 val k               +E l *var p [ prf ]+ f  = -, l *var p [ prf ]+ proj₂ (val k +E f)

--- a/src/Normalization/Negation-prop.agda
+++ b/src/Normalization/Negation-prop.agda
@@ -23,7 +23,7 @@ open import Relation.Nullary.Decidable
 open import Relation.Nullary.Negation
 open import Relation.Nullary.Product
 open import Relation.Nullary.Sum
-open import Relation.Binary.SetoidReasoning
+open import Relation.Binary.Reasoning.MultiSetoid
 
 NNF-dec : ∀ {n φ} → NNF {n} φ → ∀ ρ → Dec (⟦ φ ⟧ ρ)
 NNF-dec T          ρ = yes _

--- a/src/Normalization/Qelimination-prop.agda
+++ b/src/Normalization/Qelimination-prop.agda
@@ -26,7 +26,7 @@ open import Relation.Nullary as RN using (Dec; yes; no)
 open import Relation.Nullary.Negation
 import Relation.Nullary.Decidable as DEC
 open import Relation.Binary.PropositionalEquality
-open import Relation.Binary.SetoidReasoning
+open import Relation.Binary.Reasoning.MultiSetoid
 
 
 Qfree-dec : ∀ {n f} (φ : QFree {n} f) ρ → Dec (⟦ f ⟧ ρ)

--- a/src/Normalization/Unitarization-prop.agda
+++ b/src/Normalization/Unitarization-prop.agda
@@ -99,7 +99,7 @@ open import Relation.Binary.PropositionalEquality
     eq : k′ ℤ.* k ≡ (s ℤ.◃ 1) ℤ.* toℤ σ
     eq = ZProp.◃-≡ sign-eq ∣eq∣
 
-open import Relation.Binary.SetoidReasoning
+open import Relation.Binary.Reasoning.MultiSetoid
 
 ⟦unit_⟧ : ∀ {σ n φ} (p : Div {ℕ.suc n} σ φ) → ∀ ρ {x} →
           ⟦ φ ⟧ (x ∷ ρ) ↔ ⟦ proj₁ (unit p) ⟧ (toℤ (proj₂ σ) ℤ.* x ∷ ρ)

--- a/src/Normalization/Unitarization.agda
+++ b/src/Normalization/Unitarization.agda
@@ -40,7 +40,7 @@ unit-k≠0 e = from≢0 (subst (λ k → ℤ.+ k ≢ ℤ.+ 0) (sym (unit-k-pos e
 
 -- Unitarization itself
 
-unit-E : ∀ {σ n e} → Div-E σ e → ∃ (Unit-E {n})
+unit-E : ∀ {σ n e} → Div-E σ {n} e → ∃ (Unit-E {n})
 unit-E (val k)                = -, val k
 unit-E (c*varn p + e)         = -, varn p + e
 unit-E {σ , σ≠0} (k [ k∣σ ]*var0+ e) =

--- a/src/Properties-prop.agda
+++ b/src/Properties-prop.agda
@@ -60,8 +60,9 @@ abstract
 
   Lin-E^wk : ∀ {n p₁ p₂} {e : exp n} → p₂ ℕ.≤ p₁ → Lin-E p₁ e → Lin-E p₂ e
   Lin-E^wk p₂≤p₁ (val k)               = val k
-  Lin-E^wk p₂≤p₁ (k *var p [ prf ]+ e) = k *var p [ prf′ ]+ e
-    where prf′ = ≤-trans p₂≤p₁ prf
+  Lin-E^wk {p₂ = p₂} p₂≤p₁ (k *var p [ prf ]+ e) = k *var p [ prf′ ]+ e
+    where prf′ : p₂ ℕ.≤ toℕ p
+          prf′ = ≤-trans p₂≤p₁ prf
 
   Unit-Lin-E : ∀ {n} {e : exp n} → Unit-E e → Lin-E 0 e
   Unit-Lin-E (val k)             = val k

--- a/src/Semantics-prop.agda
+++ b/src/Semantics-prop.agda
@@ -7,7 +7,7 @@ open import Data.Fin as Fin using (Fin)
 open import Relation.Binary.PropositionalEquality
 
 open import Data.Vec
-import Data.Vec.Relation.Pointwise.Inductive as VecEq
+import Data.Vec.Relation.Binary.Pointwise.Inductive as VecEq
 open import Function
 
 open import Representation

--- a/src/StdlibCompat.agda
+++ b/src/StdlibCompat.agda
@@ -1,0 +1,12 @@
+module StdlibCompat where
+
+open import Relation.Binary using (Setoid)
+import Relation.Binary.Reasoning.MultiSetoid as ≋-Reasoning
+
+module _ {c ℓ} {S : Setoid c ℓ} where
+
+  open Setoid S renaming (_≈_ to _≈_)
+
+  _↔⟨_⟩_ : ∀ x {y z} → x ≈ y → ≋-Reasoning.IsRelatedTo S y z → ≋-Reasoning.IsRelatedTo S x z
+  x ↔⟨ x≡y ⟩ y≡z = ≋-Reasoning.step-≈ x y≡z x≡y
+  infixr 2 _↔⟨_⟩_


### PR DESCRIPTION
In #4 I asked about how to update the library to support newer versions of Agda and the standard library, but it seems I already managed: no more `TERMINATING`!

Hence the question in this PR is: what needs to be done on formatting in order to get this merged into the main repository? Presumably quite a lot.

Thanks!